### PR TITLE
update readme and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,24 @@ This repository contains the smart contracts for the [Alpha Vaults](https://alph
 
 Feel free to [join our discord](https://discord.gg/6BY3Fq2) if you have any questions.
 
-
 ### Usage
+
+Install brownie
+
+`pip3 install eth-brownie`
+
+Install node modules and ganache
+
+`npm install`
+
+`npm install -g ganache-cli`
 
 Before compiling, run below. The uniswap-v3-periphery package has to be cloned
 otherwise imports don't work.
+
+`brownie pm install Uniswap/uniswap-v3-periphery@1.0.0`
+
+and then
 
 `brownie pm clone Uniswap/uniswap-v3-periphery@1.0.0`
 
@@ -23,7 +36,6 @@ To deploy, modify the parameters in `scripts/deploy_mainnet.py` and run:
 To trigger a rebalance, run:
 
 `brownie run rebalance`
-
 
 ### Bug Bounty
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,7 +1,7 @@
+from _pytest.monkeypatch import MonkeyPatch
 from brownie.test import given, strategy
-from hypothesis import settings
+from hypothesis import HealthCheck, settings
 from pytest import approx
-
 
 MAX_EXAMPLES = 5  # faster
 # MAX_EXAMPLES = 50
@@ -18,7 +18,7 @@ def getPrice(pool):
     buy=strategy("bool"),
     qty=strategy("uint256", min_value=1e3, max_value=1e18),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_deposit_invariants(
     vault,
     strategy,
@@ -83,7 +83,7 @@ def test_deposit_invariants(
     buy=strategy("bool"),
     qty=strategy("uint256", min_value=1e3, max_value=1e18),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_rebalance_invariants(
     vault,
     strategy,
@@ -136,7 +136,7 @@ def test_rebalance_invariants(
     buy=strategy("bool"),
     qty=strategy("uint256", min_value=1e3, max_value=1e18),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_cannot_make_instant_profit_from_deposit_then_withdraw(
     vault,
     strategy,
@@ -185,7 +185,7 @@ def test_cannot_make_instant_profit_from_deposit_then_withdraw(
     qty2=strategy("uint256", min_value=1e3, max_value=1e18),
     manipulateBack=strategy("bool"),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_cannot_make_instant_profit_from_manipulated_deposit(
     vault,
     strategy,
@@ -257,7 +257,7 @@ def test_cannot_make_instant_profit_from_manipulated_deposit(
     qty2=strategy("uint256", min_value=1e3, max_value=1e18),
     manipulateBack=strategy("bool"),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_cannot_make_instant_profit_from_manipulated_withdraw(
     vault,
     strategy,
@@ -326,7 +326,7 @@ def test_cannot_make_instant_profit_from_manipulated_withdraw(
     qty=strategy("uint256", min_value=1e3, max_value=1e18),
     qty2=strategy("uint256", min_value=1e3, max_value=1e18),
 )
-@settings(max_examples=MAX_EXAMPLES)
+@settings(max_examples=MAX_EXAMPLES, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_cannot_make_instant_profit_around_rebalance(
     vault,
     strategy,


### PR DESCRIPTION
get these errors on the test suite:

```
hypothesis.errors.FailedHealthCheck: tests/test_invariants.py::test_cannot_make_instant_profit_around_rebalance uses the 'vault' 
fixture, which is reset between function calls but not between test cases generated by `@given(...)`.  You can change it to a 
module- or session-scoped fixture if it is safe to reuse; if not we recommend using a context manager inside your test function. 
 See https://docs.pytest.org/en/latest/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session 
for details on fixture scope.

E                               See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you
 want to disable just this health check, add HealthCheck.function_scoped_fixture to the suppress_health_check settings for this test.

../../../.local/lib/python3.8/site-packages/hypothesis/extra/pytestplugin.py:199: FailedHealthCheck
============================================================== short test summary info ===============================================================
FAILED tests/test_invariants.py::test_rebalance_invariants - hypothesis.errors.FailedHealthCheck: tests/test_invariants.py::test_rebalance_invarian...
FAILED tests/test_invariants.py::test_cannot_make_instant_profit_from_deposit_then_withdraw - hypothesis.errors.FailedHealthCheck: tests/test_invar...
FAILED tests/test_invariants.py::test_cannot_make_instant_profit_from_manipulated_deposit - hypothesis.errors.FailedHealthCheck: tests/test_invaria...
FAILED tests/test_invariants.py::test_cannot_make_instant_profit_from_manipulated_withdraw - hypothesis.errors.FailedHealthCheck: tests/test_invari...
FAILED tests/test_invariants.py::test_cannot_make_instant_profit_around_rebalance - hypothesis.errors.FailedHealthCheck: tests/test_invariants.py::...
============================================================ 5 failed, 1 passed in 26.59s ============================================================
```

id also like to add github CI and package management to the project but ganache and poetry don't seem to like each other (can't pass compiler flags to poetry)